### PR TITLE
correct resize drop decision

### DIFF
--- a/src/hpack_index.erl
+++ b/src/hpack_index.erl
@@ -129,7 +129,7 @@ lookup(Idx, #dynamic_table{table=T}) ->
 
 -spec resize(pos_integer(), dynamic_table()) -> dynamic_table().
 resize(NewSize, DT=#dynamic_table{size=S})
-    when NewSize =< S ->
+    when NewSize >= S ->
         DT#dynamic_table{max_size=NewSize};
 resize(NewSize, DT) ->
     resize(NewSize, droplast(DT)).

--- a/test/hpack_index_tests.erl
+++ b/test/hpack_index_tests.erl
@@ -11,3 +11,32 @@ resize_test() ->
     DT3 = hpack_index:add(<<"--eight-">>,<<"--eight-">>,DT2),
     ?assertEqual(48, hpack_index:table_size(DT3)),
     ok.
+
+increase_max_size_test() ->
+    DT = hpack_index:new(64),
+
+    %% add data, less than max size
+    DT2 = hpack_index:add(<<"keyA">>, <<"valA">>, DT),
+    ?assertEqual(40, %% 32 + length("keyA") + length("valA")
+                 hpack_index:table_size(DT2)),
+
+    %% increase max size
+    DT3 = hpack_index:resize(128, DT2),
+
+    %% what fit before should still fit
+    ?assertEqual(hpack_index:table_size(DT2),
+                 hpack_index:table_size(DT3)).
+
+decrease_max_size_test() ->
+    DT = hpack_index:new(64),
+
+    %% add data, less than max size
+    DT2 = hpack_index:add(<<"keyA">>, <<"valA">>, DT),
+    ?assertEqual(40, %% 32 + length("keyA") + length("valA")
+                 hpack_index:table_size(DT2)),
+
+    %% reduce max size below current size
+    DT3 = hpack_index:resize(32, DT2),
+
+    %% the lone entry should have been removed, it didn't fit
+    ?assertEqual(0, hpack_index:table_size(DT3)).


### PR DESCRIPTION
It was dropping the last entry when the new max size was greater than
the current size, and keeping it when the new max size was less than the
current size. It now does the opposite.
