### PR TITLE
Allow a custom index matcher

### DIFF
--- a/src/hpack_index.erl
+++ b/src/hpack_index.erl
@@ -23,6 +23,7 @@
     size = 0 :: non_neg_integer()
     }).
 -type dynamic_table() :: #dynamic_table{}.
+-export_type([dynamic_table/0]).
 
 -spec new() -> dynamic_table().
 new() -> #dynamic_table{}.


### PR DESCRIPTION
Some upstreams require some (arbitrary) headers
to be either indexed or not depending on when the
request is made. This is done so that application
developers can optimize the size of the dynamic
tables.

This PR allows the user of the library to specify
a custom index matching function which is called
for every header sent it, and therefore allows for
custom indexing or not based on requirements.
