### PR TITLE
Fixes table size change bug

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ rebar3
 _build
 erln8.config
 *.beam
+.rebar3
+ebin

--- a/Makefile
+++ b/Makefile
@@ -6,12 +6,16 @@ REBAR3 = $(CURDIR)/rebar3
 endif
 
 # Fallback to rebar on PATH
-REBAR3 ?= $(shell test -e `which rebar3` 2>/dev/null && which rebar3 || echo "./rebar3")
+REBAR3 ?= $(shell which rebar3)
 
 # And finally, prep to download rebar if all else fails
 ifeq ($(REBAR3),)
 REBAR3 = $(CURDIR)/rebar3
 endif
+
+clean: $(REBAR3)
+	@$(REBAR3) clean
+	rm -rf _build
 
 all: $(REBAR3)
 	@$(REBAR3) do clean, compile, eunit, ct, dialyzer

--- a/README.md
+++ b/README.md
@@ -45,3 +45,79 @@ to do in order to read a compressed header block from various
 PUSH_PROMISE, HEADERS, and/or CONTINUATION frames. Once you have a
 complete block, you can use this library to turn it into something you
 can use for fulfilling HTTP requests
+
+## API
+
+### Creating Contexts
+
+Encoding Contexts and Decoding Contexts are now the same type. You can
+create new one with `hpack:new_context()` or pass an argument which is
+an integer of byte size provided by HTTP/2's `HEADER_TABLE_SIZE`
+setting.
+
+### Changing table size
+
+If HTTP/2 settings get renegotiated, you can pass that information
+along by calling `hpack:new_max_table_size/2`, like this:
+
+``` erlang
+NewContext = hpack:new_max_table_size(NewSize, OldContext),
+```
+
+### Decoding Headers
+
+Decode a headers binary with `hpack:decode/2`. It's your job to
+assemble the binary if it's coming from multiple HTTP/2 frames.
+
+``` erlang
+{Headers, NewContext} = hpack:decode(Binary, OldContext),
+```
+
+Headers is of type `[{binary(), binary()}]`
+
+### Encoding Headers
+
+Encoding headers works the same way, only a `[{binary(), binary()}]`
+goes in, and a `binary()` comes out.
+
+``` erlang
+{Bin, NewContext} = hpack:encode(Headers, OldContext),
+```
+
+### Soup to nuts
+
+Here's how to do the whole thing!
+
+``` erlang
+
+DecodeContext1 = hpack:new_context(), %% Server context
+EncodeContext1 = hpack:new_context(), %% client context
+
+ClientRequestHeaders = [
+        {<<":method">>, <<"GET">>},
+        {<<":path">>, <<"/">>},
+        {<<"X-Whatev">>, <<"commands">>}
+    ],
+
+%% Client operation
+{RequestHeadersBin, EncodeContext2} = hpack:encode(
+    ClientRequestHeaders,
+    EncodeContext1),
+
+%% Server operation, after receiving RequestHeadersBin
+{ServerRequestHeaders, DecodeContext2} = hpack:decode(
+    RequestHeadersBin,
+    DecodeContext1),
+
+%% Note the following truths:
+ClientRequestHeaders = ServerRequestHeaders,
+EncodeContext1 = DecodeContext1,
+EncodeContext2 = DecodeContext2.
+
+```
+
+The whole reason hpack works is that the client and server both keep
+their contexts in sync with each other.
+
+** Note: I used the terms `client` and `server` here, but it could as
+easily be `sender` and `receiver` if you're a proxy

--- a/test/hpack_tests.erl
+++ b/test/hpack_tests.erl
@@ -8,7 +8,8 @@ basic_nghttp2_request_test() ->
     Bin = <<130,132,134,65,138,160,228,29,19,157,9,184,240,30,7,83,3,42,47,42,144,
             122,138,170,105,210,154,196,192,23,117,119,127>>,
 
-    {Decoded=[H1,H2,H3,H4,H5,H6,H7], _DC} = hpack:decode(Bin, hpack:new_decode_context()),
+    {ok,
+     {Decoded=[H1,H2,H3,H4,H5,H6,H7], _DC}} = hpack:decode(Bin, hpack:new_context()),
     % :method: GET
     ?assertEqual({<<":method">>, <<"GET">>},H1),
     % :path: /
@@ -25,8 +26,8 @@ basic_nghttp2_request_test() ->
     ?assertEqual({<<"user-agent">>, <<"nghttp2/0.7.7">>},H7),
 
 
-    {ReEncoded, _EncodeContext} = hpack:encode([H1,H2,H3,H4,H5,H6,H7], hpack:new_encode_context()),
-    {ReDecoded, _} = hpack:decode(ReEncoded, hpack:new_decode_context()),
+    {ok, {ReEncoded, _EncodeContext}} = hpack:encode([H1,H2,H3,H4,H5,H6,H7], hpack:new_context()),
+    {ok, {ReDecoded, _}} = hpack:decode(ReEncoded, hpack:new_context()),
     io:format("Original : ~p~n", [Bin]),
     io:format("ReEncoded: ~p~n", [ReEncoded]),
     io:format("ReDecoded: ~p~n", [ReDecoded]),
@@ -39,9 +40,9 @@ decode_1_test() ->
             144,122,138,170,105,210,154,196,192,23,117,112,135,64,135,242,178,
             125,117,73,236,175,1,66,126,1,79,64,133,242,181,37,63,143,1,112,126,
             1,116,127,1,1,116>>,
-    {[
-        H1,H2,H3,H4,H5,H6,H7,H8,H9,H10,H11,H12
-    ], _DC} = hpack:decode(Bin, hpack:new_decode_context()),
+    {ok, {[
+           H1,H2,H3,H4,H5,H6,H7,H8,H9,H10,H11,H12
+          ], _DC}} = hpack:decode(Bin, hpack:new_context()),
 
     ?assertEqual({<<":method">>, <<"GET">>},H1),
     ?assertEqual({<<":path">>, <<"/">>},H2),
@@ -66,7 +67,7 @@ decode_c_2_1_test() ->
     ?assertEqual(Bin, BinStr),
     %% 400a 6375 7374 6f6d 2d6b 6579 0d63 7573 | @.custom-key.cus
     %% 746f 6d2d 6865 6164 6572                | tom-header
-    {[H1],_DC} = hpack:decode(Bin, hpack:new_decode_context()),
+    {ok, {[H1],_DC}} = hpack:decode(Bin, hpack:new_context()),
     ?assertEqual({<<"custom-key">>, <<"custom-header">>}, H1),
     ok.
 
@@ -76,7 +77,7 @@ decode_c_2_2_test() ->
              16#2f,16#70,16#61,16#74,16#68>>,
     %% input| 040c 2f73 616d 706c 652f 7061 7468
     %% out  | :path: /sample/path
-    {[H1],_DC} = hpack:decode(Bin, hpack:new_decode_context()),
+    {ok, {[H1],_DC}} = hpack:decode(Bin, hpack:new_context()),
     ?assertEqual({<<":path">>, <<"/sample/path">>}, H1),
     ok.
 
@@ -87,7 +88,7 @@ decode_c_2_3_test() ->
 
     %% input| 1008 7061 7373 776f 7264 0673 6563 7265 74
     %% out  | password: secret
-    {[H1],_DC} = hpack:decode(Bin, hpack:new_decode_context()),
+    {ok, {[H1],_DC}} = hpack:decode(Bin, hpack:new_context()),
     ?assertEqual({<<"password">>, <<"secret">>}, H1),
     ok.
 
@@ -96,7 +97,7 @@ decode_c_2_4_test() ->
     Bin = <<16#82>>,
     %% input| 82
     %% out  | :method: GET
-    {[H1],_DC} = hpack:decode(Bin, hpack:new_decode_context()),
+    {ok, {[H1],_DC}} = hpack:decode(Bin, hpack:new_context()),
     ?assertEqual({<<":method">>, <<"GET">>}, H1),
     ok.
 
@@ -105,7 +106,7 @@ decode_c_3_test() ->
     C_3_1 = <<16#82, 16#86, 16#84, 16#41, 16#0f, 16#77, 16#77, 16#77,
             16#2e, 16#65, 16#78, 16#61, 16#6d, 16#70, 16#6c, 16#65,
             16#2e, 16#63, 16#6f, 16#6d >>,
-    {[R1H1, R1H2, R1H3, R1H4], DC2} = hpack:decode(C_3_1, hpack:new_decode_context()),
+    {ok, {[R1H1, R1H2, R1H3, R1H4], DC2}} = hpack:decode(C_3_1, hpack:new_context()),
     io:format("DC2: ~p", [DC2]),
     ?assertEqual({<<":method">>, <<"GET">>}, R1H1),
     ?assertEqual({<<":scheme">>, <<"http">>}, R1H2),
@@ -114,7 +115,7 @@ decode_c_3_test() ->
 
     C_3_2 = <<16#82, 16#86, 16#84, 16#be, 16#58, 16#08, 16#6e, 16#6f,
             16#2d, 16#63, 16#61, 16#63, 16#68, 16#65>>,
-    {[R2H1, R2H2, R2H3, R2H4, R2H5], DC3} = hpack:decode(C_3_2, DC2),
+    {ok, {[R2H1, R2H2, R2H3, R2H4, R2H5], DC3}} = hpack:decode(C_3_2, DC2),
     io:format("DC3: ~p", [DC3]),
 
     ?assertEqual({<<":method">>, <<"GET">>}, R2H1),
@@ -127,7 +128,7 @@ decode_c_3_test() ->
               16#73, 16#74, 16#6f, 16#6d, 16#2d, 16#6b, 16#65, 16#79,
               16#0c, 16#63, 16#75, 16#73, 16#74, 16#6f, 16#6d, 16#2d,
               16#76, 16#61, 16#6c, 16#75, 16#65>>,
-    {[R3H1, R3H2, R3H3, R3H4, R3H5], DC4} = hpack:decode(C_3_3, DC3),
+    {ok, {[R3H1, R3H2, R3H3, R3H4, R3H5], DC4}} = hpack:decode(C_3_3, DC3),
     io:format("DC4: ~p", [DC4]),
     ?assertEqual({<<":method">>   , <<"GET">>}            , R3H1),
     ?assertEqual({<<":scheme">>   , <<"https">>}          , R3H2),
@@ -141,7 +142,7 @@ decode_c_4_test() ->
     C_4_1 = <<16#82, 16#86, 16#84, 16#41, 16#8c, 16#f1, 16#e3, 16#c2,
               16#e5, 16#f2, 16#3a, 16#6b, 16#a0, 16#ab, 16#90, 16#f4,
               16#ff>>,
-    {[R1H1, R1H2, R1H3, R1H4], DC2} = hpack:decode(C_4_1, hpack:new_decode_context()),
+    {ok, {[R1H1, R1H2, R1H3, R1H4], DC2}} = hpack:decode(C_4_1, hpack:new_context()),
     io:format("DC2: ~p", [DC2]),
     ?assertEqual({<<":method">>, <<"GET">>}, R1H1),
     ?assertEqual({<<":scheme">>, <<"http">>}, R1H2),
@@ -150,7 +151,7 @@ decode_c_4_test() ->
 
     C_4_2 = <<16#82, 16#86, 16#84, 16#be, 16#58, 16#86,
               16#a8, 16#eb, 16#10, 16#64, 16#9c, 16#bf>>,
-    {[R2H1, R2H2, R2H3, R2H4, R2H5], DC3} = hpack:decode(C_4_2, DC2),
+    {ok, {[R2H1, R2H2, R2H3, R2H4, R2H5], DC3}} = hpack:decode(C_4_2, DC2),
     io:format("DC3: ~p", [DC3]),
 
     ?assertEqual({<<":method">>, <<"GET">>}, R2H1),
@@ -162,7 +163,7 @@ decode_c_4_test() ->
     C_4_3 = <<16#82, 16#87, 16#85, 16#bf, 16#40, 16#88, 16#25, 16#a8,
               16#49, 16#e9, 16#5b, 16#a9, 16#7d, 16#7f, 16#89, 16#25,
               16#a8, 16#49, 16#e9, 16#5b, 16#b8, 16#e8, 16#b4, 16#bf>>,
-    {[R3H1, R3H2, R3H3, R3H4, R3H5], DC4} = hpack:decode(C_4_3, DC3),
+    {ok, {[R3H1, R3H2, R3H3, R3H4, R3H5], DC4}} = hpack:decode(C_4_3, DC3),
     io:format("DC4: ~p", [DC4]),
     ?assertEqual({<<":method">>   , <<"GET">>}            , R3H1),
     ?assertEqual({<<":scheme">>   , <<"https">>}          , R3H2),
@@ -184,7 +185,7 @@ hpack_c_1_2_test() ->
 hpack_c_2_4_test() ->
     EncodedInt = hpack_integer:encode(2,7),
     ?assertEqual(<<2:7>>, EncodedInt),
-    {Encoded, _} = hpack:encode([{<<":method">>, <<"GET">>}], hpack:new_encode_context()),
+    {ok, {Encoded, _}} = hpack:encode([{<<":method">>, <<"GET">>}], hpack:new_context()),
     ?assertEqual(<<16#82>>, Encoded),
     ok.
 
@@ -197,53 +198,72 @@ hpack_c_2_4_test() ->
 % Regression tests
 decode_indexed_static_test() ->
     Bin = <<2#10001000>>,
-    {[H1], DC2} = hpack:decode(Bin, hpack:new_decode_context()),
+    {ok, {[H1], DC2}} = hpack:decode(Bin, hpack:new_context()),
     io:format("DC2: ~p", [DC2]),
     ?assertEqual({<<":status">>, <<"200">>}, H1),
     ok.
 
 decode_literal_incremental_indexing_indexed_test() ->
     Bin = <<2#01000100, 2#00000101, "/test">>,
-    {[H1], DC2} = hpack:decode(Bin, hpack:new_decode_context()),
+    {ok, {[H1], DC2}} = hpack:decode(Bin, hpack:new_context()),
     io:format("DC2: ~p", [DC2]),
     ?assertEqual({<<":path">>, <<"/test">>}, H1),
     ok.
 
 decode_literal_incremental_indexing_new_test() ->
     Bin = <<2#01000000, 2#00001010, "custom-key", 2#00001100, "custom-value">>,
-    {[H1], DC2} = hpack:decode(Bin, hpack:new_decode_context()),
+    {ok, {[H1], DC2}} = hpack:decode(Bin, hpack:new_context()),
     io:format("DC2: ~p", [DC2]),
     ?assertEqual({<<"custom-key">>, <<"custom-value">>}, H1),
     ok.
 
 decode_literal_without_indexing_indexed_test() ->
     Bin = <<2#00001111, 2#00101011, 2#00000111, "Firefox">>,
-    {[H1], DC2} = hpack:decode(Bin, hpack:new_decode_context()),
+    {ok, {[H1], DC2}} = hpack:decode(Bin, hpack:new_context()),
     io:format("DC2: ~p", [DC2]),
     ?assertEqual({<<"user-agent">>, <<"Firefox">>}, H1),
-    ?assertEqual(DC2, hpack:new_decode_context()),
+    ?assertEqual(DC2, hpack:new_context()),
     ok.
 
 decode_literal_without_indexing_new_test() ->
     Bin = <<2#00000000, 2#00001010, "custom-key", 2#00001100, "custom-value">>,
-    {[H1], DC2} = hpack:decode(Bin, hpack:new_decode_context()),
+    {ok, {[H1], DC2}} = hpack:decode(Bin, hpack:new_context()),
     io:format("DC2: ~p", [DC2]),
     ?assertEqual({<<"custom-key">>, <<"custom-value">>}, H1),
-    ?assertEqual(DC2, hpack:new_decode_context()),
+    ?assertEqual(DC2, hpack:new_context()),
     ok.
 
 decode_literal_never_indexed_indexed_test() ->
     Bin = <<2#00011111, 2#00101011, 2#00000111, "Firefox">>,
-    {[H1], DC2} = hpack:decode(Bin, hpack:new_decode_context()),
+    {ok, {[H1], DC2}} = hpack:decode(Bin, hpack:new_context()),
     io:format("DC2: ~p", [DC2]),
     ?assertEqual({<<"user-agent">>, <<"Firefox">>}, H1),
-    ?assertEqual(DC2, hpack:new_decode_context()),
+    ?assertEqual(DC2, hpack:new_context()),
     ok.
 
 decode_literal_never_indexed_new_test() ->
     Bin = <<2#00010000, 2#00001010, "custom-key", 2#00001100, "custom-value">>,
-    {[H1], DC2} = hpack:decode(Bin, hpack:new_decode_context()),
+    {ok, {[H1], DC2}} = hpack:decode(Bin, hpack:new_context()),
     io:format("DC2: ~p", [DC2]),
     ?assertEqual({<<"custom-key">>, <<"custom-value">>}, H1),
-    ?assertEqual(DC2, hpack:new_decode_context()),
+    ?assertEqual(DC2, hpack:new_context()),
+    ok.
+
+compression_error_on_too_large_size_increase_test() ->
+    Error = hpack:decode(<<2#001:3,255,16,31:5>>, hpack:new_context()),
+    ?assertEqual({error, compression_error}, Error),
+    ok.
+
+no_compression_error_on_small_enough_adjustment_test() ->
+    {Ok, {EmptyList, _NewContext}} =
+        hpack:decode(<<2#001:3,255,16,0:5>>, hpack:new_context()),
+    ?assertEqual(ok, Ok),
+    ?assertEqual([], EmptyList),
+    ok.
+
+
+no_compression_error_on_two_adjustments_test() ->
+    {Ok, _Return} =
+        hpack:decode(<<16#20, 16#3f, 16#e1, 16#1f>>, hpack:new_context()),
+    ?assertEqual(ok, Ok),
     ok.


### PR DESCRIPTION
Better Readme? Less bugs? What's not to like?

I found the following bug in chatterbox with https://github.com/summerwind/h2spec

This fixes it.

```
  4.3. Header Compression and Decompression
    ✓ Sends invalid header block fragment
    ✓ Sends Dynamic Table Size Update (RFC 7541, 6.3)
    × Encodes Dynamic Table Size Update (RFC 7541, 6.3) after common header fields
      - The endpoint MUST terminate the connection with a connection error of type COMPRESSION_ERROR.
        Expected: GOAWAY frame (ErrorCode: COMPRESSION_ERROR)
                  Connection close
          Actual: DATA frame (Length: 16, Flags: 1)
```
