### PR TITLE
Polish the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,34 +7,22 @@ HPACK Implementation for Erlang
 This implementation was designed for use by
 [Chatterbox](http://github.com/joedevivo/chatterbox), but could be
 used by any HTTP/2 implementation (or, if something other than HTTP/2
-has need for HPACK, this would work as well)
+has need for HPACK, this would work as well).
 
 ## Why Separate?
 
-* Use by other projects
+* Use in other projects
 * A separate RFC seemed like a really clear abstraction
 
 ## What's Covered
 
-### Compression Contexts
-
-[RFC-7541 Section 2.2](http://tools.ietf.org/html/rfc7541#section-2.2)
-
-### Dynamic Table Management
-
-[RFC-7541 Section 4](http://tools.ietf.org/html/rfc7541#section-4)
-
-### Primitive Type Representations
-
-[RFC-7541 Section 5](http://tools.ietf.org/html/rfc7541#section-5)
-
-### Binary Format
-
-[RFC-7541 Section 6](http://tools.ietf.org/html/rfc7541#section-6)
-
-* Indexed Header Field Representation
-* Literal Header Field Representation
-* Dynamic Table Size Update
+* Compression contexts ([RFC-7541 Section 2.2](http://tools.ietf.org/html/rfc7541#section-2.2))
+* Dynamic table management ([RFC-7541 Section 4](http://tools.ietf.org/html/rfc7541#section-4))
+* Primitive type representations ([RFC-7541 Section 5](http://tools.ietf.org/html/rfc7541#section-5))
+* Binary format ([RFC-7541 Section 6](http://tools.ietf.org/html/rfc7541#section-6))
+  * Indexed Header Field Representation
+  * Literal Header Field Representation
+  * Dynamic Table Size Update
 
 ## What's not covered
 
@@ -50,10 +38,9 @@ can use for fulfilling HTTP requests
 
 ### Creating Contexts
 
-Encoding Contexts and Decoding Contexts are now the same type. You can
-create new one with `hpack:new_context()` or pass an argument which is
-an integer of byte size provided by HTTP/2's `HEADER_TABLE_SIZE`
-setting.
+`hpack` provides a single type that represents both encoding and decoding
+contexts. A new context can be created with `hpack:new_context/0` or
+`hpack:new_context/1` (passing the size for the `HEADER_TABLE_SIZE` setting).
 
 ### Changing table size
 
@@ -61,7 +48,7 @@ If HTTP/2 settings get renegotiated, you can pass that information
 along by calling `hpack:new_max_table_size/2`, like this:
 
 ``` erlang
-NewContext = hpack:new_max_table_size(NewSize, OldContext),
+NewContext = hpack:new_max_table_size(NewSize, OldContext).
 ```
 
 ### Decoding Headers
@@ -70,10 +57,11 @@ Decode a headers binary with `hpack:decode/2`. It's your job to
 assemble the binary if it's coming from multiple HTTP/2 frames.
 
 ``` erlang
-{Headers, NewContext} = hpack:decode(Binary, OldContext),
+{ok, {Headers, NewContext}} = hpack:decode(Binary, OldContext).
 ```
 
-Headers is of type `[{binary(), binary()}]`
+`Headers` is a list of headers, where each header is a `{binary(), binary()}`
+tuple.
 
 ### Encoding Headers
 
@@ -91,7 +79,7 @@ Here's how to do the whole thing!
 ``` erlang
 
 DecodeContext1 = hpack:new_context(), %% Server context
-EncodeContext1 = hpack:new_context(), %% client context
+EncodeContext1 = hpack:new_context(), %% Client context
 
 ClientRequestHeaders = [
         {<<":method">>, <<"GET">>},
@@ -116,8 +104,8 @@ EncodeContext2 = DecodeContext2.
 
 ```
 
-The whole reason hpack works is that the client and server both keep
+The whole reason HPACK works is that the client and server both keep
 their contexts in sync with each other.
 
-** Note: I used the terms `client` and `server` here, but it could as
-easily be `sender` and `receiver` if you're a proxy
+*Note*: I used the terms `client` and `server` here, but it could as
+easily be `sender` and `receiver` if you're a proxy.


### PR DESCRIPTION
I:
- fixed an outdated example that didn't use `{ok, ...}` as the return value for `hpack:decode/2`
- fixed some formatting here and there
- restyled the list of "What's covered" so that it reads a bit less "intrusive" (if you don't like it, I can revert of course 😃)

Let me know how everything looks!

\cc @joedevivo 
