### PR TITLE
remove lager as a dep and add hex metadata

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -3,15 +3,10 @@
 %% ex: ts=4 sw=4 ft=erlang et
 {erl_opts, [
     warnings_as_errors,
-    {parse_transform, lager_transform},
     debug_info
 ]}.
 
-{deps,
- [
-  {lager, "2.2.3",
-    {git, "git://github.com/basho/lager.git", {tag, "2.2.3"}}}
- ]}.
+{deps, []}.
 
 {cover_enabled, true}.
 

--- a/rebar.lock
+++ b/rebar.lock
@@ -1,8 +1,1 @@
-[{<<"goldrush">>,
-  {git,"git://github.com/DeadZen/goldrush.git",
-       {ref,"212299233c7e7eb63a97be2777e1c05ebaa58dbe"}},
-  1},
- {<<"lager">>,
-  {git,"git://github.com/basho/lager.git",
-       {ref,"1c42c3bffbab49b0f06c9a916b00ca4911ae6a2f"}},
-  0}].
+[].

--- a/src/hpack.app.src
+++ b/src/hpack.app.src
@@ -6,9 +6,12 @@
   {registered, []},
   {applications, [
                   kernel,
-                  stdlib,
-                  lager
+                  stdlib
                  ]},
-  {env, []}
+  {env, []},
+
+  {maintainers, ["Joe Devivo"]},
+  {licenses, ["MIT"]},
+  {links, [{"Github", "https://github.com/joedevivo/hpack"}]}
  ]}.
 %% vim: set filetype=erlang tabstop=2


### PR DESCRIPTION
Resolves https://github.com/joedevivo/hpack/issues/11 and adds hex metadata to the `.app.src` file so it can be published. I'm happy to publish to hex myself if you want.