### PR TITLE
add pkg-name as hpack-erl for hex

### DIFF
--- a/src/hpack.app.src
+++ b/src/hpack.app.src
@@ -10,6 +10,7 @@
                  ]},
   {env, []},
 
+  {pkg_name, 'hpack-erl'},
   {maintainers, ["Joe DeVivo"]},
   {licenses, ["MIT"]},
   {links, [{"Github", "https://github.com/joedevivo/hpack"}]}


### PR DESCRIPTION
There is already a package `hpack` on hex. If you are ok with this name I can publish it to hex as `hpack-erl`.